### PR TITLE
Removed async call to pipeline georadius method

### DIFF
--- a/src/daos/impl/redis/site_geo_dao_redis_impl.js
+++ b/src/daos/impl/redis/site_geo_dao_redis_impl.js
@@ -190,7 +190,7 @@ const findByGeoWithExcessCapacity = async (lat, lng, radius, radiusUnit) => {
   // Get sites within the radius and store them in a temporary sorted set.
   const sitesInRadiusSortedSetKey = keyGenerator.getTemporaryKey();
 
-  setOperationsPipeline.georadiusAsync(
+  setOperationsPipeline.georadius(
     keyGenerator.getSiteGeoKey(),
     lng,
     lat,


### PR DESCRIPTION
The method `georadiusAsync` was called on the pipeline `setOperationsPipeline` when it should be `georadius`. Even though both yielded the same results (verified via the relevant tests), the naming caused a bit of confusion since none of the methods available on the pipeline has an async counterpart.  