### PR TITLE
Redis client can now connect with TLS and >=6.0 ACL AUTH settings.

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,10 @@
     "redis": {
       "host": "localhost",
       "port": 6379,
+      "database": "0",
+      "username": "default",
       "password": null,
+      "ca-file": null,
       "keyPrefix": "ru102js"
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "private": true,
   "scripts": {
-    "dev": "./node_modules/nodemon/bin/nodemon.js",
-    "load": "node src/utils/data_loader.js --",
+    "dev": "NODE_TLS_REJECT_UNAUTHORIZED=0 ./node_modules/nodemon/bin/nodemon.js",
+    "load": "NODE_TLS_REJECT_UNAUTHORIZED=0 node src/utils/data_loader.js --",
     "lint": "./node_modules/eslint/bin/eslint.js src tests",
-    "start": "node ./src/app.js",
-    "test": "jest --no-colors",
-    "testdev": "jest --watch"
+    "start": "NODE_TLS_REJECT_UNAUTHORIZED=0 node ./src/app.js",
+    "test": "NODE_TLS_REJECT_UNAUTHORIZED=0 jest --no-colors",
+    "testdev": "NODE_TLS_REJECT_UNAUTHORIZED=0 jest --watch"
   },
   "author": "Redis",
   "engines": {
@@ -29,7 +29,7 @@
     "express-validator": "^6.0.0",
     "moment": "^2.24.0",
     "morgan": "^1.9.1",
-    "redis": "^2.8.0",
+    "redis": "2.8.0",
     "round-to": "^4.0.0",
     "shortid": "^2.2.14",
     "winston": "^3.2.1"

--- a/src/daos/impl/redis/redis_client.js
+++ b/src/daos/impl/redis/redis_client.js
@@ -1,6 +1,7 @@
 const redis = require('redis');
 const bluebird = require('bluebird');
 const config = require('better-config');
+const fs = require('fs');
 
 // Add extra definitions for RedisTimeSeries commands.
 redis.addCommand('ts.add'); // redis.ts_addAsync
@@ -13,11 +14,26 @@ bluebird.promisifyAll(redis);
 // from config.json.
 const clientConfig = {
   host: config.get('dataStores.redis.host'),
-  port: config.get('dataStores.redis.port'),
+  port: config.get('dataStores.redis.port')
 };
+
+if (config.get('dataStores.redis.database')) {
+  database: parseInt(config.get('dataStores.redis.database'))
+}
 
 if (config.get('dataStores.redis.password')) {
   clientConfig.password = config.get('dataStores.redis.password');
+}
+
+if (config.get('dataStores.redis.username')) {
+  clientConfig.username = config.get('dataStores.redis.username');
+}
+
+if (config.get('dataStores.redis.ca-file')) {
+  clientConfig.tls = {};
+  clientConfig.tls.ca = [ fs.readFileSync(config.get('dataStores.redis.ca-file')) ];
+  clientConfig.tls.rejectUnauthorized = false;
+  clientConfig.tls.requestCert = true;
 }
 
 const client = redis.createClient(clientConfig);


### PR DESCRIPTION
Added "username" field to the config.json file for redis-server version
>= 6.0 using ACL default user account for AUTH command.

Added "database" field to the config.json file to provide an option to
specify database to app data to be loaded into rather than forcing it
into an existing default database.

Added "ca-file" field to the config.json to enable TLS connnections.
redis_client.js now detects if username is present and includes in the
client config opbject.

redis_client.js now detects if a TLS CA file path is provided and
initiates TLS connection.

NODE_TLS_REJECT_UNAUTHORIZED=0 env specified in package.json script
settings to accommodate TLS connections to redis server if self-signed
certificates are in use.