### PR TITLE
updated readme and package.json - related to node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Solutions to the course programming challenges can be found on the `solutions` b
 
 In order to start and run this application, you will need:
 
-- [Node.js](https://nodejs.org/en/download/) (8.9.4 or newer, we recommend using the current Long Term Stable version)
+- [Node.js](https://nodejs.org/en/download/) (10.24.1 or newer, we recommend using the current Long Term Stable version)
 - npm (installed with Node.js)
 - Access to a local or remote installation of [Redis](https://redis.io/download) version 5 or newer (local preferred)
 - If you want to try the RedisTimeSeries exercises, you'll need to make sure that your Redis installation also has the [RedisTimeSeries Module](https://oss.redis.com/redistimeseries/) installed

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "scripts": {
-    "dev": "./node_modules/nodemon/bin/nodemon.js",
+    "dev": "nodemon",
     "load": "node src/utils/data_loader.js --",
     "lint": "./node_modules/eslint/bin/eslint.js src tests",
     "start": "node ./src/app.js",
@@ -17,7 +17,7 @@
   },
   "author": "Redis",
   "engines": {
-    "node": ">=8.9.4"
+    "node": ">=10.24.1"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
1. package.json - no need to specify path to nodemon - it is enough just leave as script name - it will run from node_modules/bin
2. min version mention must be at least v.10