### PR TITLE
Update README.md for npm run testdev command

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ To run Jest continuously in watch mode, which gives you access to menus allowing
 subsets of tests and many more options:
 
 ```
-npm testdev
+npm run testdev
 ```
 
 # Optional (but Recommended): RedisInsight


### PR DESCRIPTION

Fix: `npm testdev `doesn't work. Updated to `npm run testdev`